### PR TITLE
Replace snekfetch with node-fetch

### DIFF
--- a/commands/Fun/cleverbot.js
+++ b/commands/Fun/cleverbot.js
@@ -22,7 +22,7 @@ class CleverBot extends Command {
 
             message.channel.startTyping();
 
-            bot.ask(query, function(err, response) {
+            bot.ask(query, (err, response) => {
                 message.channel.send(response.includes("Cleverbot") ? response.replace(/Cleverbot/g, "delet") : response);
                 message.channel.stopTyping(true);
                 

--- a/commands/Fun/dadjoke.js
+++ b/commands/Fun/dadjoke.js
@@ -1,5 +1,5 @@
 const Command = require("../../base/Command.js");
-const { get } = require("snekfetch");
+const fetch = require("node-fetch");
 
 class DadJoke extends Command {
     constructor(client) {
@@ -13,14 +13,15 @@ class DadJoke extends Command {
     }
 
     async run(message, args, level, settings, texts) { // eslint-disable-line no-unused-vars
-        try {
-          const { raw } = await get("https://icanhazdadjoke.com/").set("Accept", "text/plain");
-          const text = raw.toString();
-          message.channel.send(text);
-        } catch (error) {
+      const meta = { "Accept": "text/plain" };
+
+      fetch("https://icanhazdadjoke.com/", { headers: meta })
+        .then(res => res.text())
+        .then(body => message.channel.send(body))
+        .catch(error => {
           this.client.logger.error(error);
           return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
-        }
+        });
     }
 }
 

--- a/commands/Fun/expand.js
+++ b/commands/Fun/expand.js
@@ -1,5 +1,5 @@
 const Command = require("../../base/Command.js");
-const snekfetch = require("snekfetch");
+const fetch = require("node-fetch");
 
 class Expand extends Command {
     constructor(client) {
@@ -14,14 +14,18 @@ class Expand extends Command {
     async run(message, args, level, settings, texts) { // eslint-disable-line no-unused-vars
         const text = encodeURIComponent(args.join(" "));
         if (!text) return message.channel.send("You must provide some text to expand.");
-        try {
-            const { body } = await snekfetch.get(`http://artii.herokuapp.com/make?text=${text}`);
-            if (body.length > 2000) return message.channel.send("Unfortunately, the specified text is too long. Please try again with something a little shorter.");
-            return message.channel.send(body, { code: "fix" });
-        } catch (error) {
-            this.client.logger.error(error);
-            return message.channel.send(texts.general.error.replace(/{{err}}/g, error));
-        }
+        const tooLong = "Unfortunately, the specified text is too long. Please try again with something a little shorter.";
+        
+        fetch(`http://artii.herokuapp.com/make?text=${text}`)
+            .then(res => res.text())
+            .then(body => {
+                if (body.length > 2000) return message.channel.send(tooLong);
+                return message.channel.send(body, { code: "fix" });
+            })
+            .catch(error => {
+                this.client.logger.error(error);
+                return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
+            });
     }
 }
 

--- a/commands/Fun/joke.js
+++ b/commands/Fun/joke.js
@@ -1,6 +1,5 @@
 const Command = require("../../base/Command.js");
-const snekfetch = require("snekfetch");
-const { RichEmbed } = require("discord.js");
+const fetch = require("node-fetch");
 
 class Joke extends Command {
     constructor(client) {
@@ -14,22 +13,13 @@ class Joke extends Command {
     }
 
     async run(message, args, level, settings, texts) { // eslint-disable-line no-unused-vars
-        const randomColor = "#0000".replace(/0/g, () => {
-          return (~~(Math.random() * 16)).toString(16);
-        });
-        
-        try {
-          const { body } = await snekfetch.get("https://08ad1pao69.execute-api.us-east-1.amazonaws.com/dev/random_joke");
-          const embed = new RichEmbed()
-            .setColor(randomColor)
-            .setAuthor("Joke", "https://vgy.me/hLZJX4.png")
-            .setDescription(`${body.setup}\n*${body.punchline}*`)
-            .setFooter(`Category: ${body.type.toProperCase()}`);
-          return message.channel.send({ embed });
-        } catch (error) {
+      fetch("https://official-joke-api.appspot.com/random_joke")
+        .then(res => res.json())
+        .then(data => message.channel.send(`${data.setup} ${data.punchline}`))
+        .catch(error => {
           this.client.logger.error(error);
           return message.channel.send(texts.general.error.replace(/{{err}}/g, error));
-        }
+        });
     }
 }
 

--- a/commands/Fun/urban.js
+++ b/commands/Fun/urban.js
@@ -1,6 +1,6 @@
 const Command = require("../../base/Command.js");
 const { RichEmbed } = require("discord.js");
-const { get } = require("snekfetch");
+const fetch = require("node-fetch");
 
 class Urban extends Command {
     constructor(client) {
@@ -17,24 +17,26 @@ class Urban extends Command {
         const query = args.join(" ");
         if (!query) return message.channel.send("You must provide a term to search for.");
 
-        try {
-            const { body } = await get(`http://api.urbandictionary.com/v0/define?term=${query}`);
-            const data = body.list[0];
-
-            const embed = new RichEmbed()
-                .setColor(50687)
-                .setAuthor("Urban Dictionary", "https://vgy.me/ScvJzi.jpg")
-                .setDescription(`Displaying Urban Dictionary definition for "**${data.word}**"\n<${data.permalink}>`)
-                .addField("» Definition", `**${data.definition.replace(/[[\]]+/g, "")}**`) // this regex removes square brackets from definitions
-                .addField("» Example", data.example.replace(/[[\]]+/g, ""))
-                .setFooter(`Definition 1 of ${body.list.length}`)
-                .setTimestamp();
-
-            message.channel.send({ embed });
-        } catch (error) {
-            this.client.logger.error(error);
-            return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
-        }
+        fetch(`http://api.urbandictionary.com/v0/define?term=${query}`)
+            .then(res => res.json())
+            .then(json => {
+                const data = json.list[0];
+                const definition = data.definition.replace(/[[\]]+/g, "");
+                const example = data.example.replace(/[[\]]+/g, "");
+                const embed = new RichEmbed()
+                    .setColor(50687)
+                    .setAuthor("Urban Dictionary", "https://vgy.me/ScvJzi.jpg")
+                    .setDescription(`Displaying Urban Dictionary definition for "**${data.word}**"\n<${data.permalink}>`)
+                    .addField("» Definition", `**${definition.substring(0, 1000)}...**`)
+                    .addField("» Example", `${example.substring(0, 1000)}...`)
+                    .setFooter(`Definition 1 of ${json.list.length}`)
+                    .setTimestamp();
+                return message.channel.send({ embed });
+            })
+            .catch(error => {
+                this.client.logger.error(error);
+                return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
+            });
     }
 }
 

--- a/commands/Image/cat.js
+++ b/commands/Image/cat.js
@@ -1,5 +1,5 @@
 const Command = require("../../base/Command.js");
-const snekfetch = require("snekfetch");
+const fetch = require("node-fetch");
 
 class Cat extends Command {
     constructor(client) {
@@ -13,14 +13,17 @@ class Cat extends Command {
 
     async run(message, args, level, settings, texts) { // eslint-disable-line no-unused-vars
         message.channel.startTyping();
-        try {
-            const { body } = await snekfetch.get("http://aws.random.cat/meow");
-            message.channel.stopTyping(true);
-            return message.channel.send({ file: body.file });
-        } catch (error) {
-            this.client.logger.error(error);
-            return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
-        }
+
+        fetch("https://aws.random.cat/meow")
+            .then(res => res.json())
+            .then(data => message.channel.send({ file: data.file }))
+            .catch(error => {
+                this.client.logger.error(error);
+                message.channel.stopTyping(true);
+                return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
+            });
+
+        message.channel.stopTyping(true);
     }
 }
 

--- a/commands/Image/changemymind.js
+++ b/commands/Image/changemymind.js
@@ -1,5 +1,5 @@
 const Command = require("../../base/Command.js");
-const snekfetch = require("snekfetch");
+const fetch = require("node-fetch");
 
 class ChangeMyMind extends Command {
     constructor(client) {
@@ -13,19 +13,22 @@ class ChangeMyMind extends Command {
     }
 
     async run(message, args, level, settings, texts) { // eslint-disable-line no-unused-vars
-      const text = args.join(" ");
+      let text = args.join(" ");
       if (!text) return message.channel.send("You must provide some text to appear on the image.");
+      else text = encodeURIComponent(args.join(" "));
 
       message.channel.startTyping();
 
-      try {
-        const { body } = await snekfetch.get(`https://nekobot.xyz/api/imagegen?type=changemymind&text=${encodeURIComponent(text)}`);
-        message.channel.send("", { file: body.message });
+      fetch(`https://nekobot.xyz/api/imagegen?type=changemymind&text=${text}`)
+        .then(res => res.json())
+        .then(data => message.channel.send({ file: data.message }))
+        .catch(error => {
+          this.client.logger.error(error);
+          message.channel.stopTyping(true);
+          return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
+        });
+        
         message.channel.stopTyping(true);
-      } catch (error) {
-        this.client.logger.error(error);
-        return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
-      }
     }
 }
 

--- a/commands/Image/dog.js
+++ b/commands/Image/dog.js
@@ -1,5 +1,5 @@
 const Command = require("../../base/Command.js");
-const snekfetch = require("snekfetch");
+const fetch = require("node-fetch");
 
 class Dog extends Command {
     constructor(client) {
@@ -13,14 +13,17 @@ class Dog extends Command {
 
     async run(message, args, level, settings, texts) { // eslint-disable-line no-unused-vars
         message.channel.startTyping();
-        try {
-            const { body } = await snekfetch.get("https://dog.ceo/api/breeds/image/random");
-            message.channel.stopTyping(true);
-            return message.channel.send({ file: body.message });
-        } catch (error) {
-            this.client.logger.error(error);
-            return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
-        }
+
+        fetch("https://dog.ceo/api/breeds/image/random")
+            .then(res => res.json())
+            .then(data => message.channel.send({ file: data.message }))
+            .catch(error => {
+                this.client.logger.error(error);
+                message.channel.stopTyping(true);
+                return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
+            });
+
+        message.channel.stopTyping(true);
     }
 }
 

--- a/commands/Image/giphy.js
+++ b/commands/Image/giphy.js
@@ -1,5 +1,6 @@
 const Command = require("../../base/Command.js");
-const snekfetch = require("snekfetch");
+const fetch = require("node-fetch");
+const { URLSearchParams } = require("url");
 const { GIPHY_API_KEY } = process.env;
 
 class Giphy extends Command {
@@ -16,21 +17,21 @@ class Giphy extends Command {
     async run(message, args, level, settings, texts) { // eslint-disable-line no-unused-vars
         const query = args[0];
         if (!query) return message.channel.send("You must provide a query to return a GIF for.");
-
-        try {
-            const { body } = await snekfetch
-                .get("http://api.giphy.com/v1/gifs/search")
-                .query({
-                    q: query,
-                    api_key: GIPHY_API_KEY,
-                    rating: "pg"
-                });
-            if (!body.data.length) return message.channel.send("No GIFs found.");
-            return message.channel.send(body.data.random().images.original.url);
-        } catch (error) {
-            this.client.logger.error(error);
-            return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
-        }
+        
+        const url = "http://api.giphy.com/v1/gifs/search?";
+        const params = new URLSearchParams({
+            q: query,
+            api_key: GIPHY_API_KEY,
+            rating: "pg"
+        });
+        
+        fetch(url + params)
+            .then(res => res.json())
+            .then(json => message.channel.send(json.data.random().images.original.url))
+            .catch(error => {
+                this.client.logger.error(error);
+                return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
+            });
     }
 }
 

--- a/commands/Image/image.js
+++ b/commands/Image/image.js
@@ -1,5 +1,5 @@
 const Command = require("../../base/Command.js");
-const { get } = require("snekfetch");
+const fetch = require("node-fetch");
 
 class Image extends Command {
     constructor(client) {
@@ -18,14 +18,15 @@ class Image extends Command {
 
         message.channel.startTyping();
 
-        try {
-            const { raw } = await get(`https://source.unsplash.com/random/${size}`);
-            message.channel.send("", { files: [{ attachment: raw, name: "image.jpg" }] });
-            return message.channel.stopTyping(true);
-        } catch (error) {
-            this.client.logger.error(error);
-            return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
-        }
+        fetch(`https://source.unsplash.com/random/${size}`)
+            .then(res => message.channel.send({ files: [{ attachment: res.body, name: "image.jpg" }] })
+            .catch(error => {
+                this.client.logger.error(error);
+                message.channel.stopTyping(true);
+                return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
+            }));
+
+        message.channel.stopTyping(true);
     }
 }
 

--- a/commands/Image/imagesearch.js
+++ b/commands/Image/imagesearch.js
@@ -1,5 +1,5 @@
 const Command = require("../../base/Command.js");
-const snekfetch = require("snekfetch");
+const fetch = require("node-fetch");
 const { RichEmbed } = require("discord.js");
 const { UNSPLASH_ACCESS_KEY } = process.env;
 
@@ -15,8 +15,9 @@ class ImageSearch extends Command {
     }
 
     async run(message, args, level, settings, texts) { // eslint-disable-line no-unused-vars
-        const query = args.join(" ");
+        let query = args.join(" ");
         if (!query) return message.channel.send("You must specify a search query.");
+        else query = encodeURIComponent(args.join(" "));
 
         const page = Math.floor(Math.random() * 5) + 1;
         const index = Math.floor(Math.random() * 10) + 1;
@@ -25,31 +26,31 @@ class ImageSearch extends Command {
           return (~~(Math.random() * 16)).toString(16);
         });
 
+        const meta = { "Authorization": `Client-ID ${UNSPLASH_ACCESS_KEY}` };
+
         message.channel.startTyping();
 
-        try {
-          const { body } = await snekfetch
-            .get(`https://api.unsplash.com/search/photos?page=${page}`)
-            .query({ query: encodeURIComponent(query) })
-            .set({ Authorization: `Client-ID ${UNSPLASH_ACCESS_KEY}` });
+        fetch(`https://api.unsplash.com/search/photos?page=${page}&query=${query}`, { headers: meta })
+          .then(res => res.json())
+          .then(json => {
+            const data = json.results[parseInt(index.toFixed(0))];
+            const embed = new RichEmbed()
+              .setTitle("📷 Image")
+              .setURL(data.urls.raw)
+              .setDescription(`Photo by [${data.user.name}](${data.user.links.html}) on [Unsplash](https://unsplash.com)`)
+              .setImage(data.urls.raw)
+              .setColor(randomColor)
+              .setTimestamp();
+            message.channel.send({ embed });
+          })
+          .catch(error => {
+            message.channel.stopTyping(true);
+            if (error.message === "Cannot read property 'urls' of undefined") return message.channel.send(texts.general.noResultsFound);
+            this.client.logger.error(error);
+            return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
+          });
 
-          const data = body.results[parseInt(index.toFixed(0))];
-
-          const embed = new RichEmbed()
-            .setTitle("📷 Image")
-            .setURL(data.urls.raw)
-            .setDescription(`Photo by [${data.user.name}](${data.user.links.html}) on [Unsplash](https://unsplash.com)`)
-            .setImage(data.urls.raw)
-            .setColor(randomColor)
-            .setTimestamp();
-          message.channel.send({ embed });
-          return message.channel.stopTyping(true);
-        } catch (error) {
-          message.channel.stopTyping(true);
-          if (error.message === "Cannot read property 'urls' of undefined") return message.channel.send(texts.general.noResultsFound);
-          this.client.logger.error(error);
-          return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
-        }
+        message.channel.stopTyping(true);
     }
 }
 

--- a/commands/Image/jpeg.js
+++ b/commands/Image/jpeg.js
@@ -1,5 +1,5 @@
 const Command = require("../../base/Command.js");
-const snekfetch = require("snekfetch");
+const fetch = require("node-fetch");
 
 class JPEG extends Command {
     constructor(client) {
@@ -18,15 +18,18 @@ class JPEG extends Command {
 
       message.channel.startTyping();
 
-      try {
-        const { body } = await snekfetch.get(`https://nekobot.xyz/api/imagegen?type=jpeg&url=${url}`);
-        if (body.success === false) return message.channel.send("An error occurred. Please ensure the URL you're providing is an image URL.");
-        message.channel.stopTyping(true);
-        return message.channel.send("", { file: body.message });
-      } catch (error) {
-        this.client.logger.error(error);
-        return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
-      }
+      fetch(`https://nekobot.xyz/api/imagegen?type=jpeg&url=${url}`)
+        .then(res => res.json())
+        .then(data => {
+          if (!data.success) return message.channel.send("An error occurred. Please ensure the URL you're providing is an image URL.");
+          message.channel.stopTyping(true);
+          return message.channel.send({ file: data.message });
+        })
+        .catch(error => {
+          this.client.logger.error(error);
+          message.channel.stopTyping(true);
+          return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
+        });
     }
 }
 

--- a/commands/Image/lizard.js
+++ b/commands/Image/lizard.js
@@ -1,5 +1,5 @@
 const Command = require("../../base/Command.js");
-const snekfetch = require("snekfetch");
+const fetch = require("node-fetch");
 
 class Lizard extends Command {
     constructor(client) {
@@ -13,14 +13,17 @@ class Lizard extends Command {
 
     async run(message, args, level, settings, texts) { // eslint-disable-line no-unused-vars
         message.channel.startTyping();
-        try {
-            const { body } = await snekfetch.get("https://nekos.life/api/v2/img/lizard");
-            message.channel.stopTyping(true);
-            return message.channel.send({ file: body.url });
-        } catch (error) {
-            this.client.logger.error(error);
-            return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
-        }
+
+        fetch("https://nekos.life/api/v2/img/lizard")
+            .then(res => res.json())
+            .then(data => message.channel.send({ file: data.url }))
+            .catch(error => {
+                this.client.logger.error(error);
+                message.channel.stopTyping(true);
+                return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
+            });
+
+        message.channel.stopTyping(true);
     }
 }
 

--- a/commands/Image/magik.js
+++ b/commands/Image/magik.js
@@ -1,5 +1,5 @@
 const Command = require("../../base/Command.js");
-const snekfetch = require("snekfetch");
+const fetch = require("node-fetch");
 
 class Magik extends Command {
     constructor(client) {
@@ -17,15 +17,18 @@ class Magik extends Command {
 
       message.channel.startTyping();
 
-      try {
-        const { body } = await snekfetch.get(`https://nekobot.xyz/api/imagegen?type=magik&image=${url}`);
-        if (body.success === false) return message.channel.send("An error occurred. Please ensure the URL you're providing is an image URL.");
-        message.channel.stopTyping(true);
-        return message.channel.send("", { file: body.message });
-      } catch (error) {
-        this.client.logger.error(error);
-        return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
-      }
+      fetch(`https://nekobot.xyz/api/imagegen?type=magik&image=${url}`)
+        .then(res => res.json())
+        .then(data => {
+          if (!data.success) return message.channel.send("An error occurred. Please ensure the URL you're providing is an image URL.");
+          message.channel.stopTyping(true);
+          return message.channel.send({ file: data.message });
+        })
+        .catch(error => {
+          this.client.logger.error(error);
+          message.channel.stopTyping(true);
+          return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
+        });
     }
 }
 

--- a/commands/Image/robot.js
+++ b/commands/Image/robot.js
@@ -1,5 +1,5 @@
 const Command = require("../../base/Command.js");
-const { get } = require("snekfetch");
+const fetch = require("node-fetch");
 
 class Robot extends Command {
     constructor(client) {
@@ -19,14 +19,15 @@ class Robot extends Command {
 
         message.channel.startTyping();
 
-        try {
-          const { raw } = await get(`https://robohash.org/${query}.png`);
-          message.channel.stopTyping();
-          return message.channel.send(`*"${query}"*`, { file: raw });
-        } catch (error) {
-          this.client.logger.error(error);
-          return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
-        }
+        fetch(`https://robohash.org/${encodeURIComponent(query)}.png`)
+          .then(res => message.channel.send({ files: [{ attachment: res.body, name: `${query}.png` }] })
+          .catch(error => {
+            this.client.logger.error(error);
+            message.channel.stopTyping(true);
+            return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
+          }));
+
+        message.channel.stopTyping(true);
     }
 }
 

--- a/commands/Image/snake.js
+++ b/commands/Image/snake.js
@@ -1,5 +1,5 @@
 const Command = require("../../base/Command.js");
-const snekfetch = require("snekfetch");
+const fetch = require("node-fetch");
 const { RichEmbed } = require("discord.js");
 const { UNSPLASH_ACCESS_KEY } = process.env;
 
@@ -22,31 +22,31 @@ class Snake extends Command {
           return (~~(Math.random() * 16)).toString(16);
         });
 
+        const meta = { "Authorization": `Client-ID ${UNSPLASH_ACCESS_KEY}` };
+
         message.channel.startTyping();
 
-        try {
-          const { body } = await snekfetch
-            .get(`https://api.unsplash.com/search/photos?page=${page}`)
-            .query({ query: "snake" })
-            .set({ Authorization: `Client-ID ${UNSPLASH_ACCESS_KEY}` });
+        fetch(`https://api.unsplash.com/search/photos?page=${page}&query=snake`, { headers: meta })
+          .then(res => res.json())
+          .then(json => {
+            const data = json.results[parseInt(index.toFixed(0))];
+            const embed = new RichEmbed()
+              .setTitle("🐍 Snake")
+              .setURL(data.urls.raw)
+              .setDescription(`Photo by [${data.user.name}](${data.user.links.html}) on [Unsplash](https://unsplash.com)`)
+              .setImage(data.urls.raw)
+              .setColor(randomColor)
+              .setTimestamp();
+            message.channel.send({ embed });
+          })
+          .catch(error => {
+            message.channel.stopTyping(true);
+            if (error.message === "Cannot read property 'urls' of undefined") return message.channel.send(texts.general.noResultsFound);
+            this.client.logger.error(error);
+            return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
+          });
 
-          const data = body.results[parseInt(index.toFixed(0))];
-
-          const embed = new RichEmbed()
-            .setTitle("🐍 Snake")
-            .setURL(data.urls.raw)
-            .setDescription(`Photo by [${data.user.name}](${data.user.links.html}) on [Unsplash](https://unsplash.com)`)
-            .setImage(data.urls.raw)
-            .setColor(randomColor)
-            .setTimestamp();
-          message.channel.send({ embed });
-          return message.channel.stopTyping(true);
-        } catch (error) {
-          message.channel.stopTyping(true);
-          if (error.message === "Cannot read property 'urls' of undefined") return message.channel.send("An error occurred during the request. Please try again.");
-          this.client.logger.error(error);
-          return message.channel.send(texts.general.error.replace(/{{err}}/g, error.message));
-        }
+        message.channel.stopTyping(true);
     }
 }
 


### PR DESCRIPTION
**Type**

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

**Description of the changes**
delet currently uses [snekfetch](https://www.npmjs.com/package/snekfetch) to handle HTTP requests to APIs, but this module has now been deprecated by its author and is therefore no longer supported, meaning future security vulnerabilities most likely will not be patched.

This PR replaces all instances of snekfetch with the more popular [node-fetch](https://www.npmjs.com/package/node-fetch), and also changes the appropriate methods.